### PR TITLE
fix merger.determineConflict for initial lines from right tokens

### DIFF
--- a/src/heckel-diff.ts
+++ b/src/heckel-diff.ts
@@ -87,8 +87,8 @@ export default class HeckelDiff {
   identifyUniquePositions() : Array<UniquePositions> {
     const leftUniques = this.findUnique(this.left);
     const rightUniques = this.findUnique(this.right);
-    const leftKeys = new Set(...leftUniques.keys());
-    const rightKeys = new Set(...rightUniques.keys());
+    const leftKeys = new Set(leftUniques.keys());
+    const rightKeys = new Set(rightUniques.keys());
     const sharedKeys = new Set([...leftKeys].filter(k => rightKeys.has(k)));
 
     const uniqRanges = [...sharedKeys].map((k) => {

--- a/src/merger.ts
+++ b/src/merger.ts
@@ -66,9 +66,7 @@ export default class Merger {
   determineConflict(d: ChangeRange[], left: string[], right: string[]) {
     let ia = 1;
     d.forEach((changeRange) => {
-      for(let lineno = ia; lineno <= changeRange.leftLo; lineno++) {
-        this.result.push(new Resolved(this.accumulateLines(ia, lineno, right)));
-      }
+      this.result.push(new Resolved(this.accumulateLines(ia, changeRange.leftLo, right)));
 
       const outcome = this.determineOutcome(changeRange, left, right);
       ia = changeRange.rightHi + 1;

--- a/test/three-way-merge-test.ts
+++ b/test/three-way-merge-test.ts
@@ -41,3 +41,15 @@ QUnit.test('reasonable merge performance', assert => {
   assert.equal(merged.joinedResults(), expected,
                "merges reasonably quickly");
 });
+
+QUnit.test('merge jsons', assert => {
+  const strBase = '{"enabled":false}';
+  const strLeft = '{"enabled":true,"other":1}';
+  const strRight = '{"enabled":true}';
+  const merged = merge(strLeft, strBase, strRight);
+  assert.equal(merged.conflict, false,
+               'has no merge conflicts');
+  
+  assert.equal(merged.joinedResults(), strLeft);
+});
+


### PR DESCRIPTION
Suggested solution for
https://github.com/movableink/three-way-merge/issues/3